### PR TITLE
Only return locations with a value for the requested measure

### DIFF
--- a/src/measurement/measurement.repository.ts
+++ b/src/measurement/measurement.repository.ts
@@ -21,6 +21,12 @@ class MeasurementRepository {
       measureSelectQuery = `m.pm25, m.pm10, m.atmp, m.rhum, m.rco2, m.o3, m.no2`;
     }
 
+    // Only include rows that include for the requested measure.
+    var measureWhereQuery: string = "";
+    if (measure) {
+      measureWhereQuery = `WHERE m.${measure} IS NOT NULL`;
+    }
+
     const query = ` 
             WITH latest_measurements AS (
                 SELECT 
@@ -45,6 +51,7 @@ class MeasurementRepository {
                 measurement m ON lm.location_id = m.location_id AND lm.last_measured_at = m.measured_at
             JOIN 
                 location l ON m.location_id = l.id
+            ${measureWhereQuery}
             ORDER BY 
                 lm.location_id 
             OFFSET $1 LIMIT $2; 


### PR DESCRIPTION
Ex URL: /api/v1/measurements/current?measure=rco2&page=1&pagesize=100

When a measure is included, it should only return locations that don’t have a null value for that measure.

Fixes #16 