### PR TITLE
Mark sensors as offline if no measurements received in the last 6 hours

### DIFF
--- a/src/measurement/measurement.repository.ts
+++ b/src/measurement/measurement.repository.ts
@@ -86,6 +86,8 @@ class MeasurementRepository {
                         coordinate,
                         ST_MakeEnvelope($1, $2, $3, $4, 3857)
                     )
+                AND
+                    m.measured_at  >= NOW() - INTERVAL '6 hours'
                 GROUP BY 
                     l.id
             )

--- a/src/measurement/measurement.repository.ts
+++ b/src/measurement/measurement.repository.ts
@@ -11,8 +11,6 @@ class MeasurementRepository {
     limit: number = 100,
     measure?: string,
   ): Promise<Measurement[]> {
-    // TODO: How about offline, need to check if the last measurement is already past the "offline" threshold?
-
     // Define measure type that are expected
     var measureSelectQuery: string = "";
     if (measure) {
@@ -28,7 +26,8 @@ class MeasurementRepository {
                     last(measured_at, measured_at) AS last_measured_at
                 FROM 
                     measurement
-                GROUP BY 
+                WHERE measured_at  >= NOW() - INTERVAL '6 hours'
+                GROUP BY
                     location_id
             )
             SELECT 
@@ -122,4 +121,3 @@ class MeasurementRepository {
 }
 
 export default MeasurementRepository;
-


### PR DESCRIPTION
## Problem

The following endpoints currently treat outdated measurements as if they are still current, even when the last measurement from a location was sent over a month ago:

1. `measurements/current`
2. `measurements/current/area`
3. `measurements/current/cluster`

## Changes

Introduced the concept of offline: if the latest measurement from a sensor is older than **6** hours, the sensor is now considered offline. So it will not included to those endpoints response, especially `cluster` endpoint that have an averaging process.

Issue #15 


